### PR TITLE
Add `next` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+elm-stuff

--- a/src/Task/Extra.elm
+++ b/src/Task/Extra.elm
@@ -3,7 +3,7 @@ module Task.Extra where
 for tasks.
 
 # Chaining Tasks
-@docs optional, parallel, next
+@docs optional, parallel, next, nextFromError
 
 # Communicating with Mailboxes
 @docs broadcast, intercept, interceptSuccess, interceptError
@@ -46,6 +46,18 @@ for easier use with pipes.
 next : (a -> Task x b) -> Task x a -> Task x b
 next =
   flip Task.andThen
+
+
+{-| Flipped version of [Task.onError](http://package.elm-lang.org/packages/elm-lang/core/2.1.0/Task#onError)
+for easier use with pipes.
+
+    Http.get decoder url
+        |> nextFromError (\err -> makeSomeTask err)
+        |> nextFromError (\anotherErr -> makeAnotherTask anotherErr)
+-}
+nextFromError : (x -> Task y a) -> Task x a -> Task y a
+nextFromError =
+  flip Task.onError
 
 
 {-| Sends a value to a list of addresses at once.

--- a/src/Task/Extra.elm
+++ b/src/Task/Extra.elm
@@ -3,7 +3,7 @@ module Task.Extra where
 for tasks.
 
 # Chaining Tasks
-@docs optional, parallel
+@docs optional, parallel, next
 
 # Communicating with Mailboxes
 @docs broadcast, intercept, interceptSuccess, interceptError
@@ -34,6 +34,18 @@ for re-ordering or consider integrating a sorting mechanism within your program.
 parallel : List (Task error value) -> Task error (List ThreadID)
 parallel tasks =
   sequence (List.map spawn tasks)
+
+
+{-| Flipped version of [Task.andThen](http://package.elm-lang.org/packages/elm-lang/core/2.1.0/Task#andThen)
+for easier use with pipes.
+
+    Http.get decoder url
+        |> next (\result -> makeSomeTask result)
+        |> next (\anotherResult -> makeAnotherTask anotherResult)
+-}
+next : (a -> Task x b) -> Task x a -> Task x b
+next =
+  flip Task.andThen
 
 
 {-| Sends a value to a list of addresses at once.


### PR DESCRIPTION
This implements @laszlopandy's [suggestion about `andThen`](https://groups.google.com/forum/#!msg/elm-discuss/m8-xgu7Tu-k/bRMeaNSvAgAJ) while renaming it to `next` to avoid a naming collision.

Also implements a flipped version of `onError` called `nextFromError`.
